### PR TITLE
Add `proxy.OCSP`

### DIFF
--- a/proxy/ocsp.go
+++ b/proxy/ocsp.go
@@ -1,0 +1,31 @@
+package proxy
+
+import (
+	"strings"
+
+	"golang.org/x/net/publicsuffix"
+)
+
+// ocspHosts contains OCSP hosts that aren't ocsp.<TLD>
+var ocspHosts = []string{
+	"ocsp.int-x3.letsencrypt.org",
+}
+
+func OCSP(host string) bool {
+	host = strings.ToLower(host)
+
+	if strings.HasPrefix(host, "ocsp.") {
+		ps, ok := publicsuffix.PublicSuffix(host)
+		if ok && strings.HasSuffix(host, ps) {
+			return true
+		}
+	}
+
+	for _, h := range ocspHosts {
+		if host == h || strings.HasSuffix(host, "."+h) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/proxy/proxy_handler.go
+++ b/proxy/proxy_handler.go
@@ -24,6 +24,11 @@ func ProxyHandler(writer http.ResponseWriter, request *http.Request) {
 	fmt.Print(time.Now().Format("2006-01-02 15:04:05"), " ", host)
 
 	if request.Method == http.MethodGet {
+		if OCSP(host) {
+			pass(writer, request)
+			return
+		}
+
 		ctx, cancel := context.WithTimeout(request.Context(), 5*time.Second)
 		defer cancel()
 


### PR DESCRIPTION
Determine whether host is an OCSP domain and prevent upgrading to HTTPS